### PR TITLE
Hiding code text area by default

### DIFF
--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -68,6 +68,10 @@
 	padding: 0;
 }
 
+#code {
+    display: none;
+}
+
 #preview_container {
 	background-color: #F3F3F3;
 	overflow: hidden;


### PR DESCRIPTION
This should close #57.

I believe there is several ways how to fix this issue, but this one seems to be simplest.

I have tested locally with `Fiddler` throttling, even on slowest connections textarea will not appear until editor is fully loaded.